### PR TITLE
Stop playback if Kodi is playing any media

### DIFF
--- a/default.py
+++ b/default.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import urllib
 import urlparse
+import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
@@ -106,4 +107,6 @@ elif mode[0] == 'folder':
     cmd = lutris
     if slug != 'lutris':
         cmd = cmd + ' lutris:rungame/' + slug
+    if xbmc.Player().isPlaying() == True:
+        xbmc.Player().stop()
     os.system(cmd)


### PR DESCRIPTION
When launching the Lutris GUI or any of the listed games from the add-on playback will be stopped if Kodi is playing any media.

The problem I’m trying to solve is that I often listen to music, then decide I want to do a bit of gaming. If I forget to stop playback before I launch a game, the playback continues since the game is launched in a different window and Kodi is not aware of this. I then have to quit the game, stop the audio playback and relaunch the game.

This PR detects if Kodi is playing anything, and if it is the playback is stopped.